### PR TITLE
feature/auth: auth 명세서, 폴더 구조 변경, entity,

### DIFF
--- a/src/auth/auth.controller.spec.ts
+++ b/src/auth/auth.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AuthController } from './auth.controller';
+
+describe('AuthController', () => {
+  let controller: AuthController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [AuthController],
+    }).compile();
+
+    controller = module.get<AuthController>(AuthController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -1,7 +1,8 @@
 import { Body, Controller, Post, Res } from '@nestjs/common';
 import { AuthService } from './auth.service';
-import { RegisterDto } from './dtos/register.dto';
-import { LoginDto } from './dtos/login.dto';
+import { RegisterRequestDto } from './dtos/register.dto';
+import { LoginRequestDto } from './dtos/login.dto';
+import { Docs } from 'src/decorator/docs/auth.decorator';
 
 @Controller('auth')
 export class AuthController {
@@ -9,22 +10,26 @@ export class AuthController {
 
 
   @Post('register')
-  async signUp(@Body() registerDto: RegisterDto) {
-    return await this.authService.register(registerDto);
+  @Docs('register')
+  async signUp(@Body() registerRequestDto: RegisterRequestDto) {
+    return await this.authService.register(registerRequestDto);
   }
 
   @Post('login')
-  async login(@Body() loginDto: LoginDto) {
-    return await this.authService.login(loginDto);
+  @Docs('login')
+  async login(@Body() loginRequestDto: LoginRequestDto) {
+    return await this.authService.login(loginRequestDto);
   }
 
   @Post('logout')
+  @Docs('logout')
   async logout(@Res() res: Response) {
     return await this.authService.logout();
   }
 
   @Post('refresh-token')
-  async renewToken(@Body() loginDto: LoginDto) {
+  @Docs('refresh-token')
+  async renewToken(@Body() loginDto: LoginRequestDto) {
     return this.authService.renewToken();
   }
 }

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -1,0 +1,30 @@
+import { Body, Controller, Post, Res } from '@nestjs/common';
+import { AuthService } from './auth.service';
+import { RegisterDto } from './dtos/register.dto';
+import { LoginDto } from './dtos/login.dto';
+
+@Controller('auth')
+export class AuthController {
+  constructor(private readonly authService: AuthService) { }
+
+
+  @Post('register')
+  async signUp(@Body() registerDto: RegisterDto) {
+    return await this.authService.register(registerDto);
+  }
+
+  @Post('login')
+  async login(@Body() loginDto: LoginDto) {
+    return await this.authService.login(loginDto);
+  }
+
+  @Post('logout')
+  async logout(@Res() res: Response) {
+    return await this.authService.logout();
+  }
+
+  @Post('refresh-token')
+  async renewToken(@Body() loginDto: LoginDto) {
+    return this.authService.renewToken();
+  }
+}

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -1,4 +1,9 @@
 import { Module } from '@nestjs/common';
+import { AuthController } from './auth.controller';
+import { AuthService } from './auth.service';
 
-@Module({})
+@Module({
+  controllers: [AuthController],
+  providers: [AuthService]
+})
 export class AuthModule {}

--- a/src/auth/auth.service.spec.ts
+++ b/src/auth/auth.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AuthService } from './auth.service';
+
+describe('AuthService', () => {
+  let service: AuthService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [AuthService],
+    }).compile();
+
+    service = module.get<AuthService>(AuthService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -1,0 +1,23 @@
+import { Injectable } from '@nestjs/common';
+import { RegisterDto } from './dtos/register.dto';
+import { LoginDto } from './dtos/login.dto';
+
+@Injectable()
+export class AuthService {
+  async register(registerDto: RegisterDto): Promise<void> {
+
+  }
+
+  async login(loginDto: LoginDto): Promise<void> {
+
+  }
+
+  async logout(): Promise<void> {
+    
+  }
+
+  async renewToken(): Promise<void> {
+
+  }
+
+}

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -1,19 +1,19 @@
 import { Injectable } from '@nestjs/common';
-import { RegisterDto } from './dtos/register.dto';
-import { LoginDto } from './dtos/login.dto';
+import { RegisterRequestDto } from './dtos/register.dto';
+import { LoginRequestDto } from './dtos/login.dto';
 
 @Injectable()
 export class AuthService {
-  async register(registerDto: RegisterDto): Promise<void> {
+  async register(registerRequestDto: RegisterRequestDto): Promise<void> {
 
   }
 
-  async login(loginDto: LoginDto): Promise<void> {
+  async login(loginDto: LoginRequestDto): Promise<void> {
 
   }
 
   async logout(): Promise<void> {
-    
+
   }
 
   async renewToken(): Promise<void> {

--- a/src/auth/dtos/login.dto.ts
+++ b/src/auth/dtos/login.dto.ts
@@ -1,0 +1,15 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsString, Length } from 'class-validator';
+
+export class LoginDto {
+  @IsString()
+  @IsNotEmpty()
+  @ApiProperty({ example: "0100000000" })
+  userId: string;
+
+  @IsString()
+  @IsNotEmpty()
+  @Length(8)
+  @ApiProperty({ example: "root00))" })
+  password: string;
+}

--- a/src/auth/dtos/login.dto.ts
+++ b/src/auth/dtos/login.dto.ts
@@ -1,7 +1,7 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsNotEmpty, IsString, Length } from 'class-validator';
 
-export class LoginDto {
+class LoginRequestDto {
   @IsString()
   @IsNotEmpty()
   @ApiProperty({ example: "0100000000" })
@@ -13,3 +13,16 @@ export class LoginDto {
   @ApiProperty({ example: "root00))" })
   password: string;
 }
+
+class LoginResponseDto {
+  @ApiProperty({ example: "xxxx.xxxx.xxxx" })
+  refreshToken: string;
+
+  @ApiProperty({ example: "xxxx.xxxx.xxxx" })
+  accessToken: string;
+
+  @ApiProperty({ example: "1" })
+  id: number;
+}
+
+export { LoginRequestDto, LoginResponseDto }

--- a/src/auth/dtos/register.dto.ts
+++ b/src/auth/dtos/register.dto.ts
@@ -1,0 +1,43 @@
+import { ApiProperty } from "@nestjs/swagger";
+import { IsDate, IsIn, IsNotEmpty, IsString, Length } from "class-validator";
+
+export class RegisterDto {
+  @IsString()
+  @IsNotEmpty()
+  @ApiProperty({ example: "이름이지" })
+  name: string;
+
+  @IsString()
+  @IsNotEmpty()
+  @ApiProperty({ example: "0100000000" })
+  userId: string;
+
+  @IsString()
+  @IsNotEmpty()
+  @Length(8)
+  @ApiProperty({ example: "root00))" })
+  password: string;
+
+  @IsString()
+  @IsNotEmpty()
+  @ApiProperty({ example: "닉네임이지" })
+  nickname: string;
+
+  @IsDate()
+  @ApiProperty({ example: "1900-01-01" })
+  birthday: Date;
+
+  @IsString()
+  @ApiProperty({ example: "남성" })
+  gender: string;
+
+  @IsString()
+  @IsNotEmpty()
+  @IsIn(['choreography', 'kpop', 'hiphop', 'girls_hiphop', 'girlish', 'waacking', 'hillchoreo', 'b_boy', 'krump', 'popping', 'house', 'street', 'jazz', 'korean_dance', 'modern_dance', 'ballet', 'breaking', 'latin', 'large_group_dance', 'freestyle'])
+  @ApiProperty({ example: "힙합" })
+  genre: string[];
+
+  @IsString()
+  @ApiProperty({ example: "서울특별시 성북구 안암로 145" })
+  address: string;
+}

--- a/src/auth/dtos/register.dto.ts
+++ b/src/auth/dtos/register.dto.ts
@@ -1,7 +1,7 @@
 import { ApiProperty } from "@nestjs/swagger";
 import { IsDate, IsIn, IsNotEmpty, IsString, Length } from "class-validator";
 
-export class RegisterDto {
+class RegisterRequestDto {
   @IsString()
   @IsNotEmpty()
   @ApiProperty({ example: "이름이지" })
@@ -28,16 +28,32 @@ export class RegisterDto {
   birthday: Date;
 
   @IsString()
-  @ApiProperty({ example: "남성" })
+  @ApiProperty({ example: "male" })
   gender: string;
 
   @IsString()
   @IsNotEmpty()
   @IsIn(['choreography', 'kpop', 'hiphop', 'girls_hiphop', 'girlish', 'waacking', 'hillchoreo', 'b_boy', 'krump', 'popping', 'house', 'street', 'jazz', 'korean_dance', 'modern_dance', 'ballet', 'breaking', 'latin', 'large_group_dance', 'freestyle'])
-  @ApiProperty({ example: "힙합" })
+  @ApiProperty({ example: "kpop" })
   genre: string[];
 
   @IsString()
   @ApiProperty({ example: "서울특별시 성북구 안암로 145" })
   address: string;
 }
+
+class RegisterResponseDto {
+  @ApiProperty({ example: "닉네임이지" })
+  nickname: string;
+
+  @ApiProperty({ example: "xxxx.xxxx.xxxx" })
+  refreshToken: string;
+
+  @ApiProperty({ example: "xxxx.xxxx.xxxx" })
+  accessToken: string;
+
+  @ApiProperty({ example: "1" })
+  id: number;
+}
+
+export { RegisterRequestDto, RegisterResponseDto }

--- a/src/decorator/docs/auth.decorator.ts
+++ b/src/decorator/docs/auth.decorator.ts
@@ -1,0 +1,78 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiBody, ApiCreatedResponse, ApiHeader, ApiOkResponse, ApiOperation, ApiUnauthorizedResponse } from '@nestjs/swagger';
+import { LoginRequestDto, LoginResponseDto } from 'src/auth/dtos/login.dto';
+import { RegisterRequestDto, RegisterResponseDto } from 'src/auth/dtos/register.dto';
+
+type EndPoints =
+  | 'register'
+  | 'login'
+  | 'logout'
+  | 'refresh-token';
+
+export function Docs(endPoint: EndPoints) {
+  switch (endPoint) {
+    case 'register': return applyDecorators(
+      ApiOperation({
+        description: "유저 정보를 받아 회원가입",
+        summary: "회원가입"
+      }),
+      ApiBody({
+        type: RegisterRequestDto,
+      }),
+      ApiCreatedResponse({
+        description: "회원가입 성공",
+        type: RegisterResponseDto
+      })
+    );
+    case 'login': return applyDecorators(
+      ApiOperation({
+        description: "전화번호(userId), 비밀번호(password) 받아 로그인",
+        summary: "로그인"
+      }),
+      ApiBody({
+        type: LoginRequestDto
+      }),
+      ApiCreatedResponse({
+        description: "로그인 성공",
+        type: LoginResponseDto
+      }),
+      ApiUnauthorizedResponse({
+        description: "로그인 실패"
+      })
+    );
+    case 'logout': return applyDecorators(
+      ApiOperation({
+        description: "로그아웃. 토큰 삭제를 위해 refresh token 받음",
+        summary: "로그아웃"
+      }),
+      ApiHeader({
+        description: 'header => authorization => bearer 에 refresh token 주세요',
+        name: 'header',
+        required: true,
+      }),
+      ApiOkResponse({
+        description: "로그아웃 성공"
+      }),
+      ApiUnauthorizedResponse({
+        description: "로그아웃 실패"
+      })
+    );
+    case 'refresh-token': return applyDecorators(
+      ApiOperation({
+        description: "refresh token을 헤더로 받아 access token을 갱신",
+        summary: "토큰 갱신"
+      }),
+      ApiHeader({
+        description: 'header => authorization => bearer 에 refresh token 주세요',
+        name: 'header',
+        required: true,
+      }),
+      ApiCreatedResponse({
+        description: "토큰 갱신 성공"
+      }),
+      ApiUnauthorizedResponse({
+        description: "토큰 갱신 실패"
+      })
+    );
+  }
+}

--- a/src/entities/follow.entity.ts
+++ b/src/entities/follow.entity.ts
@@ -1,0 +1,14 @@
+import { CreateDateColumn, Entity, ManyToOne, PrimaryGeneratedColumn } from "typeorm";
+import { User } from "./user.entity";
+
+@Entity()
+export class Follow {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @CreateDateColumn()
+  followedAt: Date;
+
+  @ManyToOne(() => User, user => user.follows, { onDelete: "CASCADE" })
+  user: User;
+}

--- a/src/entities/user.entity.ts
+++ b/src/entities/user.entity.ts
@@ -1,0 +1,62 @@
+import { Column, PrimaryGeneratedColumn, ManyToMany, Entity, OneToMany } from 'typeorm';
+import { Follow } from './follow.entity';
+
+@Entity()
+export class User {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  userId: string;
+
+  @Column()
+  name: string;
+
+  @Column()
+  password: string;
+
+  @Column()
+  nickname: string;
+
+  @Column()
+  birthday: Date;
+
+  @Column()
+  gender: string;
+
+  @Column()
+  description: string;
+
+  @Column()
+  level: number;
+
+  @Column()
+  address: string;
+
+  @Column()
+  blueCheck: boolean;
+
+  
+  /*
+  @ManyToMany(() => Genre)
+  genres: Genre[];
+
+  @ManyToMany(() => Lecture)
+  learningLectures: Lecture[];
+
+  @ManyToMany(() => Lecture)
+  teachingLectures: Lecture[];
+
+  @OneToMany(() => Review)
+  reviews: Review[];
+
+  @OneToOne(() => Certification)
+  certification: Certification;
+  
+  */
+
+  @OneToMany(() => Follow, follow => follow.user)
+  follows: Follow[];
+
+
+}


### PR DESCRIPTION
### **# 작업내용**

- 폴더 구조 변경
    - student, instructor => user로 통합
    - decorator 내 docs 추가: swagger 문서를 모아 놓는 폴더
    
- auth 명세서
    - register, login, logout, refresh-token
    
- entity
    - user, follow 생성. 생성되지 않은 table과의 relation은 주석 처리.